### PR TITLE
Add product retrieval API

### DIFF
--- a/backend/controllers/product.controller.js
+++ b/backend/controllers/product.controller.js
@@ -1,0 +1,36 @@
+const Sellable = require('../models/sellable.model');
+
+// Get all products
+exports.getAllProducts = async (req, res) => {
+  try {
+    const products = await Sellable.find({ type: 'product' })
+      .populate('businessId', 'name');
+    res.json(products);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+// Get products by business
+exports.getProductsByBusiness = async (req, res) => {
+  try {
+    const { businessId } = req.params;
+    const products = await Sellable.find({ businessId, type: 'product' })
+      .populate('businessId', 'name');
+    res.json(products);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+// Get a product by ID
+exports.getProductById = async (req, res) => {
+  try {
+    const product = await Sellable.findOne({ _id: req.params.id, type: 'product' })
+      .populate('businessId', 'name');
+    if (!product) return res.status(404).json({ message: 'Product not found' });
+    res.json(product);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};

--- a/backend/routes/product.routes.js
+++ b/backend/routes/product.routes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const {
+  getAllProducts,
+  getProductsByBusiness,
+  getProductById,
+} = require('../controllers/product.controller');
+
+router.get('/', getAllProducts); // Public: list all products
+router.get('/business/:businessId', getProductsByBusiness); // Products for a business
+router.get('/:id', getProductById); // Detail view
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -14,6 +14,7 @@ app.use(express.json());
 app.use('/api/auth', require('./routes/auth.routes'));
 app.use('/api/owner', require('./routes/businessOwner.routes'));
 app.use('/api/businesses', require('./routes/business.routes'));
+app.use('/api/products', require('./routes/product.routes'));
 
 
 


### PR DESCRIPTION
## Summary
- add controller for reading product data from Sellable model
- expose REST routes to get products
- register product routes in the backend server

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686691aa7798832bbe59e0ce98de55d1