### PR TITLE
Add unauthorized product creation test

### DIFF
--- a/backend/controllers/product.controller.js
+++ b/backend/controllers/product.controller.js
@@ -38,6 +38,9 @@ exports.getProductById = async (req, res) => {
 // Create a new product
 exports.createProduct = async (req, res) => {
   try {
+    if (req.user.role !== 'owner') {
+      return res.status(403).json({ message: 'Not authorized' });
+    }
     const { businessId, title, description, price, inventory } = req.body;
 
     const product = new Sellable({


### PR DESCRIPTION
## Summary
- restrict `createProduct` to owners
- add a customer account in product tests
- verify a customer receives 403 when trying to create a product

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669b65f040832b97fb3f3f74d9e2b4