### PR TITLE
Implement wildcard search

### DIFF
--- a/backend/controllers/business.controller.js
+++ b/backend/controllers/business.controller.js
@@ -49,4 +49,19 @@ exports.getBusinessById = async (req, res) => {
   }
 };
 
+// Search businesses by name (wildcard)
+exports.searchBusinesses = async (req, res) => {
+  try {
+    const term = req.query.q || '';
+    const regex = new RegExp(term, 'i');
+    const businesses = await Business.find({ name: { $regex: regex } })
+      .populate('ownerId', 'name')
+      .populate('categoryId', 'name')
+      .populate('locationId', 'name');
+    res.json(businesses);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
 

--- a/backend/controllers/product.controller.js
+++ b/backend/controllers/product.controller.js
@@ -86,3 +86,16 @@ exports.deleteProduct = async (req, res) => {
     res.status(500).json({ message: 'Server error', error: err.message });
   }
 };
+
+// Search products by title (wildcard)
+exports.searchProducts = async (req, res) => {
+  try {
+    const term = req.query.q || '';
+    const regex = new RegExp(term, 'i');
+    const products = await Sellable.find({ type: 'product', title: { $regex: regex } })
+      .populate('businessId', 'name');
+    res.json(products);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};

--- a/backend/routes/business.routes.js
+++ b/backend/routes/business.routes.js
@@ -1,10 +1,16 @@
 const express = require('express');
 const router = express.Router();
 const auth = require('../middleware/auth.middleware');
-const { createBusiness, getAllBusinesses, getBusinessById, } = require('../controllers/business.controller');
+const {
+  createBusiness,
+  getAllBusinesses,
+  getBusinessById,
+  searchBusinesses,
+} = require('../controllers/business.controller');
 
 router.post('/', auth, createBusiness);        // Create business (authenticated)
 router.get('/', getAllBusinesses);             // Public: list all
+router.get('/search', searchBusinesses);       // Wildcard search
 router.get('/:id', getBusinessById);           // Public: detail view
 
 module.exports = router;

--- a/backend/routes/product.routes.js
+++ b/backend/routes/product.routes.js
@@ -7,10 +7,12 @@ const {
   createProduct,
   updateProduct,
   deleteProduct,
+  searchProducts,
 } = require('../controllers/product.controller');
 const auth = require('../middleware/auth.middleware');
 
 router.get('/', getAllProducts); // Public: list all products
+router.get('/search', searchProducts); // Wildcard search
 router.get('/business/:businessId', getProductsByBusiness); // Products for a business
 router.get('/:id', getProductById); // Detail view
 router.post('/', auth, createProduct); // Create product

--- a/backend/tests/business.test.js
+++ b/backend/tests/business.test.js
@@ -63,4 +63,12 @@ beforeAll(async () => {
     expect(res.body).toHaveProperty('business');
     expect(res.body.business.name).toBe('Async Studio');
   });
+
+  it('should search businesses by name', async () => {
+    const res = await request(app).get('/api/businesses/search').query({ q: 'Stu' });
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].name).toBe('Async Studio');
+  });
 });

--- a/backend/tests/product.test.js
+++ b/backend/tests/product.test.js
@@ -64,6 +64,14 @@ describe('Product API', () => {
     expect(res.body.length).toBeGreaterThanOrEqual(2);
   });
 
+  it('should search products by title', async () => {
+    const res = await request(app).get('/api/products/search').query({ q: 'Sec' });
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].title).toBe('Second Product');
+  });
+
   it('should get products by business', async () => {
     const res = await request(app).get(`/api/products/business/${businessId}`);
     expect(res.statusCode).toBe(200);


### PR DESCRIPTION
## Summary
- add searchBusinesses and searchProducts controllers
- expose new `/search` routes for businesses and products
- cover search functionality in tests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674a5a67ac832bb603ccd047568223