### PR TITLE
Remove create verification endpoints from admin API

### DIFF
--- a/backend/controllers/admin.controller.js
+++ b/backend/controllers/admin.controller.js
@@ -1,0 +1,152 @@
+const CustomerVerification = require('../models/customerVerification.model');
+const VerificationRequest = require('../models/verificationRequest.model');
+const Review = require('../models/review.model');
+
+function checkAdmin(req, res) {
+  if (req.user.role !== 'admin') {
+    res.status(403).json({ message: 'Not authorized' });
+    return false;
+  }
+  return true;
+}
+
+// ---- Customer Verifications ----
+
+exports.getCustomerVerifications = async (req, res) => {
+  if (!checkAdmin(req, res)) return;
+  try {
+    const verifications = await CustomerVerification.find().populate('customerId');
+    res.json(verifications);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.getCustomerVerification = async (req, res) => {
+  if (!checkAdmin(req, res)) return;
+  try {
+    const verification = await CustomerVerification.findById(req.params.id).populate('customerId');
+    if (!verification) return res.status(404).json({ message: 'Not found' });
+    res.json(verification);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.updateCustomerVerification = async (req, res) => {
+  if (!checkAdmin(req, res)) return;
+  try {
+    const verification = await CustomerVerification.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true }
+    );
+    if (!verification) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Updated', verification });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.deleteCustomerVerification = async (req, res) => {
+  if (!checkAdmin(req, res)) return;
+  try {
+    const verification = await CustomerVerification.findByIdAndDelete(req.params.id);
+    if (!verification) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+// ---- Business Verifications ----
+
+exports.getBusinessVerifications = async (req, res) => {
+  if (!checkAdmin(req, res)) return;
+  try {
+    const requests = await VerificationRequest.find().populate('ownerId');
+    res.json(requests);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.getBusinessVerification = async (req, res) => {
+  if (!checkAdmin(req, res)) return;
+  try {
+    const request = await VerificationRequest.findById(req.params.id).populate('ownerId');
+    if (!request) return res.status(404).json({ message: 'Not found' });
+    res.json(request);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.updateBusinessVerification = async (req, res) => {
+  if (!checkAdmin(req, res)) return;
+  try {
+    const request = await VerificationRequest.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true }
+    );
+    if (!request) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Updated', request });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.deleteBusinessVerification = async (req, res) => {
+  if (!checkAdmin(req, res)) return;
+  try {
+    const request = await VerificationRequest.findByIdAndDelete(req.params.id);
+    if (!request) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.getReviews = async (req, res) => {
+  if (!checkAdmin(req, res)) return;
+  try {
+    const reviews = await Review.find().populate('customerId').populate('businessId');
+    res.json(reviews);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.getReview = async (req, res) => {
+  if (!checkAdmin(req, res)) return;
+  try {
+    const review = await Review.findById(req.params.id).populate('customerId').populate('businessId');
+    if (!review) return res.status(404).json({ message: 'Not found' });
+    res.json(review);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.updateReview = async (req, res) => {
+  if (!checkAdmin(req, res)) return;
+  try {
+    const review = await Review.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!review) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Updated', review });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.deleteReview = async (req, res) => {
+  if (!checkAdmin(req, res)) return;
+  try {
+    const review = await Review.findByIdAndDelete(req.params.id);
+    if (!review) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};

--- a/backend/routes/admin.routes.js
+++ b/backend/routes/admin.routes.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../middleware/auth.middleware');
+const admin = require('../controllers/admin.controller');
+
+router.use(auth);
+
+// Customer verifications
+router.get('/customer-verifications', admin.getCustomerVerifications);
+router.get('/customer-verifications/:id', admin.getCustomerVerification);
+router.put('/customer-verifications/:id', admin.updateCustomerVerification);
+router.delete('/customer-verifications/:id', admin.deleteCustomerVerification);
+
+// Business verifications
+router.get('/business-verifications', admin.getBusinessVerifications);
+router.get('/business-verifications/:id', admin.getBusinessVerification);
+router.put('/business-verifications/:id', admin.updateBusinessVerification);
+router.delete('/business-verifications/:id', admin.deleteBusinessVerification);
+
+// Reviews
+router.get('/reviews', admin.getReviews);
+router.get('/reviews/:id', admin.getReview);
+router.put('/reviews/:id', admin.updateReview);
+router.delete('/reviews/:id', admin.deleteReview);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -16,6 +16,7 @@ app.use('/api/owner', require('./routes/businessOwner.routes'));
 app.use('/api/businesses', require('./routes/business.routes'));
 app.use('/api/products', require('./routes/product.routes'));
 app.use('/api/customers', require('./routes/customer.routes'));
+app.use('/api/admin', require('./routes/admin.routes'));
 
 // Start server
 const PORT = process.env.PORT;

--- a/backend/tests/admin.test.js
+++ b/backend/tests/admin.test.js
@@ -1,0 +1,69 @@
+const request = require('supertest');
+const app = require('../server');
+const mongoose = require('mongoose');
+const User = require('../models/user.model');
+const Customer = require('../models/customer.model');
+const Business = require('../models/business.model');
+const CustomerVerification = require('../models/customerVerification.model');
+const Review = require('../models/review.model');
+const jwt = require('jsonwebtoken');
+
+describe('Admin API', () => {
+  let adminToken, verificationId, businessId, customerId;
+
+  beforeAll(async () => {
+    await mongoose.connect(process.env.MONGO_URI);
+    await User.deleteMany({});
+    await Customer.deleteMany({});
+    await Business.deleteMany({});
+    await CustomerVerification.deleteMany({});
+    await Review.deleteMany({});
+
+    const admin = new User({ name: 'Admin', email: 'admin@test.com', password: 'hashed', role: 'admin' });
+    await admin.save();
+    adminToken = jwt.sign({ userId: admin._id, role: admin.role }, process.env.JWT_SECRET, { expiresIn: '1h' });
+
+    const user = new User({ name: 'Cust', email: 'cust@test.com', password: 'hashed', role: 'customer' });
+    await user.save();
+    const customer = new Customer({ userId: user._id });
+    await customer.save();
+    customerId = customer._id;
+
+    const business = new Business({ name: 'Biz' });
+    await business.save();
+    businessId = business._id;
+
+    const verification = new CustomerVerification({ customerId, documents: ['id.png'] });
+    await verification.save();
+    verificationId = verification._id;
+  });
+
+  afterAll(async () => {
+    await User.deleteMany({});
+    await Customer.deleteMany({});
+    await Business.deleteMany({});
+    await CustomerVerification.deleteMany({});
+    await Review.deleteMany({});
+    await mongoose.connection.close();
+  });
+
+  it('admin updates customer verification', async () => {
+    const res = await request(app)
+      .put(`/api/admin/customer-verifications/${verificationId}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ status: 'approved' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.verification.status).toBe('approved');
+  });
+
+  it('admin lists reviews', async () => {
+    await Review.create({ customerId, businessId, rating: 5, comment: 'Great' });
+
+    const listRes = await request(app)
+      .get('/api/admin/reviews')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(listRes.statusCode).toBe(200);
+    expect(Array.isArray(listRes.body)).toBe(true);
+    expect(listRes.body.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- remove create operations for customer and business verifications
- update admin routes accordingly


------
https://chatgpt.com/codex/tasks/task_e_6867679fef8c832b8f016b265572a898