### PR TITLE
Add review endpoints and tests

### DIFF
--- a/backend/controllers/review.controller.js
+++ b/backend/controllers/review.controller.js
@@ -1,0 +1,75 @@
+const Review = require('../models/review.model');
+const Customer = require('../models/customer.model');
+
+exports.createReview = async (req, res) => {
+  try {
+    if (req.user.role !== 'customer') {
+      return res.status(403).json({ message: 'Not authorized' });
+    }
+    const customer = await Customer.findOne({ userId: req.user.userId });
+    if (!customer) return res.status(404).json({ message: 'Customer not found' });
+
+    const { businessId, rating, comment } = req.body;
+    const review = new Review({
+      customerId: customer._id,
+      businessId,
+      rating,
+      comment,
+    });
+    await review.save();
+    res.status(201).json({ message: 'Review created', review });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.updateReview = async (req, res) => {
+  try {
+    if (req.user.role !== 'customer') {
+      return res.status(403).json({ message: 'Not authorized' });
+    }
+    const customer = await Customer.findOne({ userId: req.user.userId });
+    if (!customer) return res.status(404).json({ message: 'Customer not found' });
+
+    const review = await Review.findOneAndUpdate(
+      { _id: req.params.id, customerId: customer._id },
+      req.body,
+      { new: true }
+    );
+    if (!review) return res.status(404).json({ message: 'Review not found' });
+    res.json({ message: 'Review updated', review });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.deleteReview = async (req, res) => {
+  try {
+    if (req.user.role !== 'customer') {
+      return res.status(403).json({ message: 'Not authorized' });
+    }
+    const customer = await Customer.findOne({ userId: req.user.userId });
+    if (!customer) return res.status(404).json({ message: 'Customer not found' });
+
+    const review = await Review.findOneAndDelete({
+      _id: req.params.id,
+      customerId: customer._id,
+    });
+    if (!review) return res.status(404).json({ message: 'Review not found' });
+    res.json({ message: 'Review deleted' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.getReviewsByBusiness = async (req, res) => {
+  try {
+    const businessId = req.params.id;
+    const reviews = await Review.find({ businessId })
+      .populate('customerId')
+      .populate('businessId');
+    res.json(reviews);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};

--- a/backend/routes/review.routes.js
+++ b/backend/routes/review.routes.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../middleware/auth.middleware');
+const {
+  createReview,
+  updateReview,
+  deleteReview,
+  getReviewsByBusiness,
+} = require('../controllers/review.controller');
+
+// Public: list reviews for a business
+router.get('/businesses/:id/reviews', getReviewsByBusiness);
+
+// Customer actions
+router.post('/reviews', auth, createReview);
+router.put('/reviews/:id', auth, updateReview);
+router.delete('/reviews/:id', auth, deleteReview);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -17,6 +17,7 @@ app.use('/api/businesses', require('./routes/business.routes'));
 app.use('/api/products', require('./routes/product.routes'));
 app.use('/api/customers', require('./routes/customer.routes'));
 app.use('/api/admin', require('./routes/admin.routes'));
+app.use('/api', require('./routes/review.routes'));
 
 // Start server
 const PORT = process.env.PORT;

--- a/backend/tests/review.test.js
+++ b/backend/tests/review.test.js
@@ -1,0 +1,92 @@
+const request = require('supertest');
+const app = require('../server');
+const mongoose = require('mongoose');
+const User = require('../models/user.model');
+const Customer = require('../models/customer.model');
+const Business = require('../models/business.model');
+const Review = require('../models/review.model');
+const jwt = require('jsonwebtoken');
+
+describe('Review API', () => {
+  let token1, token2, businessId, reviewId;
+
+  beforeAll(async () => {
+    await mongoose.connect(process.env.MONGO_URI);
+    await User.deleteMany({});
+    await Customer.deleteMany({});
+    await Business.deleteMany({});
+    await Review.deleteMany({});
+
+    const user1 = new User({ name: 'Cust1', email: 'c1@test.com', password: 'hash', role: 'customer' });
+    await user1.save();
+    const cust1 = new Customer({ userId: user1._id });
+    await cust1.save();
+    token1 = jwt.sign({ userId: user1._id, role: user1.role }, process.env.JWT_SECRET, { expiresIn: '1h' });
+
+    const user2 = new User({ name: 'Cust2', email: 'c2@test.com', password: 'hash', role: 'customer' });
+    await user2.save();
+    const cust2 = new Customer({ userId: user2._id });
+    await cust2.save();
+    token2 = jwt.sign({ userId: user2._id, role: user2.role }, process.env.JWT_SECRET, { expiresIn: '1h' });
+
+    const biz = new Business({ name: 'Biz' });
+    await biz.save();
+    businessId = biz._id;
+  });
+
+  afterAll(async () => {
+    await User.deleteMany({});
+    await Customer.deleteMany({});
+    await Business.deleteMany({});
+    await Review.deleteMany({});
+    await mongoose.connection.close();
+  });
+
+  it('creates a review', async () => {
+    const res = await request(app)
+      .post('/api/reviews')
+      .set('Authorization', `Bearer ${token1}`)
+      .send({ businessId: businessId.toString(), rating: 5, comment: 'Great' });
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toHaveProperty('review');
+    reviewId = res.body.review._id;
+  });
+
+  it('lists reviews for a business', async () => {
+    const res = await request(app).get(`/api/businesses/${businessId}/reviews`);
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
+  });
+
+  it('updates own review', async () => {
+    const res = await request(app)
+      .put(`/api/reviews/${reviewId}`)
+      .set('Authorization', `Bearer ${token1}`)
+      .send({ comment: 'Updated' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.review.comment).toBe('Updated');
+  });
+
+  it('fails to update others review', async () => {
+    const res = await request(app)
+      .put(`/api/reviews/${reviewId}`)
+      .set('Authorization', `Bearer ${token2}`)
+      .send({ comment: 'Hacked' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('deletes own review', async () => {
+    const res = await request(app)
+      .delete(`/api/reviews/${reviewId}`)
+      .set('Authorization', `Bearer ${token1}`);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('reviews list empty after deletion', async () => {
+    const res = await request(app).get(`/api/businesses/${businessId}/reviews`);
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add review controller with create, update, delete and list-by-business logic
- expose review routes and mount them
- write Jest tests for review API

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6867aa1caf50832ba9587a7356fcafbc