### PR TITLE
Add Socket.IO support

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -1,0 +1,17 @@
+let messages = [];
+
+exports.getMessages = (req, res) => {
+  res.json(messages);
+};
+
+exports.setupSocket = (io) => {
+  io.on('connection', (socket) => {
+    socket.emit('chat history', messages);
+
+    socket.on('chat message', (msg) => {
+      const message = { id: Date.now(), text: msg };
+      messages.push(message);
+      io.emit('chat message', message);
+    });
+  });
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.16.1"
+    "mongoose": "^8.16.1",
+    "socket.io": "^4.7.5"
   },
   "devDependencies": {
     "jest": "^30.0.3",

--- a/backend/routes/chat.routes.js
+++ b/backend/routes/chat.routes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const { getMessages } = require('../controllers/chat.controller');
+
+router.get('/messages', getMessages);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,10 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
+const http = require('http');
+const { Server } = require('socket.io');
 const connectDB = require('./config/db.config');
+const { setupSocket } = require('./controllers/chat.controller');
 
 dotenv.config();
 connectDB();
@@ -18,9 +21,14 @@ app.use('/api/products', require('./routes/product.routes'));
 app.use('/api/customers', require('./routes/customer.routes'));
 app.use('/api/admin', require('./routes/admin.routes'));
 app.use('/api', require('./routes/review.routes'));
+app.use('/api/chat', require('./routes/chat.routes'));
 
 // Start server
 const PORT = process.env.PORT;
-app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+const server = http.createServer(app);
+const io = new Server(server, { cors: { origin: '*' } });
+setupSocket(io);
+
+server.listen(PORT, () => console.log(`Server running on port ${PORT}`));
 
 module.exports = app;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.4"
+    "next": "15.3.4",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { io, Socket } from 'socket.io-client';
+
+let socket: Socket | null = null;
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState<{id:number;text:string}[]>([]);
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    if (!socket) {
+      socket = io('http://localhost:5000');
+    }
+
+    socket.on('chat history', (msgs: any) => setMessages(msgs));
+    socket.on('chat message', (msg: any) =>
+      setMessages((prev) => [...prev, msg])
+    );
+
+    return () => {
+      if (socket) {
+        socket.off('chat history');
+        socket.off('chat message');
+      }
+    };
+  }, []);
+
+  const sendMessage = () => {
+    if (socket && input.trim()) {
+      socket.emit('chat message', input.trim());
+      setInput('');
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">Chat</h1>
+      <ul className="mb-4">
+        {messages.map((m) => (
+          <li key={m.id}>{m.text}</li>
+        ))}
+      </ul>
+      <div className="flex gap-2">
+        <input
+          className="border p-2 flex-grow"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-4" onClick={sendMessage}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Socket.IO to backend and wire up chat endpoints
- expose `/api/chat/messages` REST route
- create frontend chat page with Socket.IO client
- add Socket.IO dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b2e97898832bbb4741bc523f17ba