### PR TITLE
Add chat UI components

### DIFF
--- a/frontend/src/app/chat/ChatWidget.tsx
+++ b/frontend/src/app/chat/ChatWidget.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { io, Socket } from 'socket.io-client';
+
+let socket: Socket | null = null;
+
+export default function ChatWidget() {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<{ id: number; text: string }[]>([]);
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    if (!open) return;
+    if (!socket) {
+      socket = io('http://localhost:5000');
+    }
+
+    socket.on('chat history', (msgs: any) => setMessages(msgs));
+    socket.on('chat message', (msg: any) =>
+      setMessages((prev) => [...prev, msg])
+    );
+
+    return () => {
+      if (socket) {
+        socket.off('chat history');
+        socket.off('chat message');
+      }
+    };
+  }, [open]);
+
+  const sendMessage = () => {
+    if (socket && input.trim()) {
+      socket.emit('chat message', input.trim());
+      setInput('');
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="fixed bottom-4 right-4 bg-blue-600 text-white rounded-full w-12 h-12 flex items-center justify-center shadow-lg"
+      >
+        Chat
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 w-72 bg-white border shadow-lg rounded-lg p-2 text-sm">
+      <div className="flex justify-between mb-2">
+        <span className="font-bold">Chat</span>
+        <button onClick={() => setOpen(false)} className="text-gray-500">×</button>
+      </div>
+      <div className="h-48 overflow-y-auto mb-2">
+        {messages.map((m) => (
+          <div key={m.id}>{m.text}</div>
+        ))}
+      </div>
+      <div className="flex gap-1">
+        <input
+          className="border p-1 flex-grow"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-2" onClick={sendMessage}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/chat/UserSearch.tsx
+++ b/frontend/src/app/chat/UserSearch.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+
+interface User {
+  id: string;
+  name: string;
+}
+
+export default function UserSearch() {
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState<User[]>([]);
+
+  const search = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/users/search?q=${encodeURIComponent(query)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setResults(data);
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 border rounded mb-4">
+      <div className="flex gap-2">
+        <input
+          className="border p-2 flex-grow"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search users..."
+        />
+        <button
+          className="bg-blue-500 text-white px-4"
+          onClick={search}
+          disabled={loading}
+        >
+          Search
+        </button>
+      </div>
+      <ul className="mt-2">
+        {results.map((u) => (
+          <li key={u.id}>{u.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/app/chat/history/page.tsx
+++ b/frontend/src/app/chat/history/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface Conversation {
+  id: string;
+  title: string;
+}
+
+export default function ChatHistoryPage() {
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+
+  useEffect(() => {
+    fetch('/api/chat/conversations')
+      .then((res) => res.json())
+      .then((data) => setConversations(data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">Chat History</h1>
+      <ul className="space-y-2">
+        {conversations.map((c) => (
+          <li key={c.id}>
+            <Link href={`/chat/${c.id}`} className="text-blue-600 underline">
+              {c.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/app/ui/navbar";
+import ChatWidget from "@/app/chat/ChatWidget";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,6 +31,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <ChatWidget />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- create `UserSearch` component for finding users
- add `ChatHistoryPage` for recent conversations
- implement floating `ChatWidget`
- insert widget into the root layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b8491320832b8262506489f3ec2b