### PR TITLE
Implement DB-backed chat

### DIFF
--- a/backend/controllers/chat.controller.js
+++ b/backend/controllers/chat.controller.js
@@ -1,17 +1,55 @@
-let messages = [];
+const Message = require('../models/message.model');
+const Conversation = require('../models/conversation.model');
 
-exports.getMessages = (req, res) => {
-  res.json(messages);
+exports.getMessages = async (req, res) => {
+  try {
+    const { conversationId } = req.query;
+    const query = conversationId ? { conversationId } : {};
+    const msgs = await Message.find(query).sort('createdAt');
+    const formatted = msgs.map((m) => ({ id: m._id, text: m.text }));
+    res.json(formatted);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
 };
 
 exports.setupSocket = (io) => {
-  io.on('connection', (socket) => {
-    socket.emit('chat history', messages);
+  io.on('connection', async (socket) => {
+    try {
+      const msgs = await Message.find().sort('createdAt');
+      socket.emit('chat history', msgs.map((m) => ({ id: m._id, text: m.text })));
+    } catch (err) {
+      console.error('Error loading messages:', err.message);
+    }
 
-    socket.on('chat message', (msg) => {
-      const message = { id: Date.now(), text: msg };
-      messages.push(message);
-      io.emit('chat message', message);
+    socket.on('chat message', async (msg) => {
+      try {
+        const message = new Message({ text: msg });
+        await message.save();
+        io.emit('chat message', { id: message._id, text: message.text });
+      } catch (err) {
+        console.error('Error saving message:', err.message);
+      }
     });
   });
+};
+
+exports.createConversation = async (req, res) => {
+  try {
+    const { participants } = req.body;
+    const conversation = new Conversation({ participants });
+    await conversation.save();
+    res.status(201).json({ message: 'Conversation created', conversation });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+exports.listConversations = async (req, res) => {
+  try {
+    const conversations = await Conversation.find().populate('participants', 'name');
+    res.json(conversations);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
 };

--- a/backend/models/conversation.model.js
+++ b/backend/models/conversation.model.js
@@ -1,0 +1,7 @@
+const mongoose = require('mongoose');
+
+const conversationSchema = new mongoose.Schema({
+  participants: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+}, { timestamps: true });
+
+module.exports = mongoose.model('Conversation', conversationSchema);

--- a/backend/models/message.model.js
+++ b/backend/models/message.model.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const messageSchema = new mongoose.Schema({
+  text: { type: String, required: true },
+  conversationId: { type: mongoose.Schema.Types.ObjectId, ref: 'Conversation' },
+  senderId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+}, { timestamps: true });
+
+module.exports = mongoose.model('Message', messageSchema);

--- a/backend/routes/chat.routes.js
+++ b/backend/routes/chat.routes.js
@@ -1,7 +1,13 @@
 const express = require('express');
 const router = express.Router();
-const { getMessages } = require('../controllers/chat.controller');
+const {
+  getMessages,
+  createConversation,
+  listConversations,
+} = require('../controllers/chat.controller');
 
 router.get('/messages', getMessages);
+router.get('/conversations', listConversations);
+router.post('/conversations', createConversation);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- define `Conversation` and `Message` Mongoose models
- persist chat messages to MongoDB
- expose API to create and list conversations

## Testing
- `npm test --prefix backend` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b8402f74832b96b9fe01542f4629