### PR TITLE
Add user search API

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -1,0 +1,15 @@
+const User = require('../models/user.model');
+
+// Search users by name or email (wildcard)
+exports.searchUsers = async (req, res) => {
+  try {
+    const term = req.query.q || '';
+    const regex = new RegExp(term, 'i');
+    const users = await User.find({
+      $or: [{ name: { $regex: regex } }, { email: { $regex: regex } }],
+    }).select('-password');
+    res.json(users);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+
+const { searchUsers } = require('../controllers/user.controller');
+
+// Public: search users by name or email
+router.get('/search', searchUsers);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -19,6 +19,7 @@ app.use('/api/owner', require('./routes/businessOwner.routes'));
 app.use('/api/businesses', require('./routes/business.routes'));
 app.use('/api/products', require('./routes/product.routes'));
 app.use('/api/customers', require('./routes/customer.routes'));
+app.use('/api/users', require('./routes/user.routes'));
 app.use('/api/admin', require('./routes/admin.routes'));
 app.use('/api', require('./routes/review.routes'));
 app.use('/api/chat', require('./routes/chat.routes'));


### PR DESCRIPTION
## Summary
- add new user controller with /search endpoint logic
- create user routes
- wire up user routes in server.js

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b8454a90832b8ac9f00ac398dc5b