### PR TITLE
Use env var for chat socket URL

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,6 +20,12 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Required Environment Variables
+
+Set the following variables in a `.env` file or in your shell before running the frontend:
+
+- `NEXT_PUBLIC_SOCKET_URL` - URL of the Socket.IO server used by the chat
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import { io, Socket } from 'socket.io-client';
 
+const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL ?? 'http://localhost:5000';
+
 let socket: Socket | null = null;
 
 export default function ChatPage() {
@@ -11,7 +13,7 @@ export default function ChatPage() {
 
   useEffect(() => {
     if (!socket) {
-      socket = io('http://localhost:5000');
+      socket = io(SOCKET_URL);
     }
 
     socket.on('chat history', (msgs: any) => setMessages(msgs));


### PR DESCRIPTION
## Summary
- configure the chat page to read the Socket.IO endpoint from `NEXT_PUBLIC_SOCKET_URL`
- document the variable in the frontend README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b84a4bf0832b97fabddca1ea8d7b