### PR TITLE
Add chat tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "jest": "^30.0.3",
     "supertest": "^6.3.4",
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "socket.io-client": "^4.7.5"
   }
 }

--- a/backend/tests/chat.test.js
+++ b/backend/tests/chat.test.js
@@ -1,0 +1,42 @@
+const request = require('supertest');
+const app = require('../server');
+const mongoose = require('mongoose');
+const jwt = require('jsonwebtoken');
+const io = require('socket.io-client');
+
+const PORT = process.env.PORT;
+
+describe('Chat API', () => {
+  let client;
+  let token;
+
+  beforeAll(async () => {
+    await mongoose.connect(process.env.MONGO_URI);
+    token = jwt.sign({ userId: 'tester' }, process.env.JWT_SECRET, { expiresIn: '1h' });
+    client = io(`http://localhost:${PORT}`, { auth: { token } });
+    await new Promise((resolve) => client.on('connect', resolve));
+  });
+
+  afterAll(async () => {
+    client.close();
+    await mongoose.connection.close();
+  });
+
+  it('creates a conversation by sending messages', async () => {
+    const messagePromise = new Promise((resolve) => client.once('chat message', resolve));
+    client.emit('chat message', 'hello world');
+    const message = await messagePromise;
+    expect(message).toHaveProperty('text', 'hello world');
+  });
+
+  it('fetches conversation history', async () => {
+    const res = await request(app).get('/api/chat/messages');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  it('authenticates socket connection using JWT', () => {
+    expect(client.connected).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add chat test suite covering conversation creation, history and socket auth
- install `socket.io-client` for tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b84b9968832b865caed32f881f0d