### PR TITLE
Add login/register to user controller

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -1,4 +1,8 @@
 const User = require('../models/user.model');
+const bcrypt = require('bcryptjs');
+const generateToken = require('../utils/generateToken.utils');
+const Customer = require('../models/customer.model');
+const BusinessOwner = require('../models/businessOwner.model');
 
 // Search users by name or email (wildcard)
 exports.searchUsers = async (req, res) => {
@@ -9,6 +13,55 @@ exports.searchUsers = async (req, res) => {
       $or: [{ name: { $regex: regex } }, { email: { $regex: regex } }],
     }).select('-password');
     res.json(users);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+// Register a new user as customer or business owner
+exports.register = async (req, res) => {
+  try {
+    const { name, email, password, role } = req.body;
+
+    if (!['customer', 'owner'].includes(role)) {
+      return res.status(400).json({ message: 'Invalid role' });
+    }
+
+    const existingUser = await User.findOne({ email });
+    if (existingUser) {
+      return res.status(400).json({ message: 'Email already exists' });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const user = new User({ name, email, password: hashedPassword, role });
+    await user.save();
+
+    if (role === 'customer') {
+      await Customer.create({ userId: user._id });
+    } else if (role === 'owner') {
+      await BusinessOwner.create({ userId: user._id });
+    }
+
+    const token = generateToken(user);
+    res.status(201).json({ user, token });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error', error: err.message });
+  }
+};
+
+// Login existing user
+exports.login = async (req, res) => {
+  try {
+    const { email, password } = req.body;
+
+    const user = await User.findOne({ email });
+    if (!user) return res.status(400).json({ message: 'Invalid credentials' });
+
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) return res.status(400).json({ message: 'Invalid credentials' });
+
+    const token = generateToken(user);
+    res.json({ user, token });
   } catch (err) {
     res.status(500).json({ message: 'Server error', error: err.message });
   }

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const router = express.Router();
 
-const { searchUsers } = require('../controllers/user.controller');
+const { searchUsers, register, login } = require('../controllers/user.controller');
 
 // Public: search users by name or email
 router.get('/search', searchUsers);
+router.post('/register', register);
+router.post('/login', login);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- allow registering as customer or business owner via user controller
- add login endpoint to user controller
- expose new routes `/api/users/register` and `/api/users/login`

## Testing
- `npm test` *(fails: Mongoose connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686801d93bb8832b81b0cd337cdcaccd