### PR TITLE
Add login and signup pages

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('http://localhost:5000/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.message || 'Failed to login');
+      } else {
+        // success placeholder
+        setEmail('');
+        setPassword('');
+        alert('Logged in successfully');
+      }
+    } catch (err) {
+      setError('Failed to login');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow w-full max-w-md space-y-4"
+      >
+        <h1 className="text-2xl font-semibold text-center">Sign In</h1>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <div>
+          <label className="block text-sm mb-1">Email</label>
+          <input
+            type="email"
+            required
+            className="w-full border p-2 rounded"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Password</label>
+          <input
+            type="password"
+            required
+            className="w-full border p-2 rounded"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded transition"
+        >
+          {loading ? 'Loading...' : 'Login'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function SignupPage() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const register = async (role: 'customer' | 'owner') => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('http://localhost:5000/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, password, role }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.message || 'Registration failed');
+      } else {
+        setName('');
+        setEmail('');
+        setPassword('');
+        alert('Registered successfully');
+      }
+    } catch (err) {
+      setError('Registration failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow w-full max-w-md space-y-4"
+      >
+        <h1 className="text-2xl font-semibold text-center">Create Account</h1>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <div>
+          <label className="block text-sm mb-1">Name</label>
+          <input
+            type="text"
+            required
+            className="w-full border p-2 rounded"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Email</label>
+          <input
+            type="email"
+            required
+            className="w-full border p-2 rounded"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Password</label>
+          <input
+            type="password"
+            required
+            className="w-full border p-2 rounded"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <div className="flex gap-2 pt-2">
+          <button
+            type="button"
+            onClick={() => register('customer')}
+            disabled={loading}
+            className="flex-1 bg-blue-600 hover:bg-blue-700 text-white py-2 rounded transition"
+          >
+            Register as Customer
+          </button>
+          <button
+            type="button"
+            onClick={() => register('owner')}
+            disabled={loading}
+            className="flex-1 bg-purple-600 hover:bg-purple-700 text-white py-2 rounded transition"
+          >
+            Register as Owner
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement a simple login page
- implement a simple signup page with options to register as customer or business owner

## Testing
- `npm --prefix backend test` *(fails: argument handler must be a function)*
- `npm --prefix frontend run lint` *(fails: unexpected any / unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68680db1cf7c832bbbd98ed004391c7b