### PR TITLE
Add search routes to backend

### DIFF
--- a/backend/routes/search.routes.js
+++ b/backend/routes/search.routes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+
+const {
+  globalSearch,
+  getSearchSuggestions,
+} = require('../controllers/search.controller');
+
+router.get('/', globalSearch);
+router.get('/suggestions', getSearchSuggestions);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -34,6 +34,7 @@ app.use('/api/auth', require('./routes/auth.routes'));
 app.use('/api/owner', require('./routes/businessOwner.routes'));
 app.use('/api/businesses', require('./routes/business.routes'));
 app.use('/api/products', require('./routes/product.routes'));
+app.use('/api/search', require('./routes/search.routes'));
 app.use('/api/customers', require('./routes/customer.routes'));
 app.use('/api/users', require('./routes/user.routes'));
 app.use('/api/admin', require('./routes/admin.routes'));


### PR DESCRIPTION
## Summary
- create `search.routes.js` for global search endpoints
- register search routes in `server.js`

## Testing
- `npm test` *(fails: argument handler must be a function)*

------
https://chatgpt.com/codex/tasks/task_e_6868b90d771c832badd5dc3c17c19969