### PR TITLE
Remove unused rating sort option

### DIFF
--- a/backend/controllers/search.controller.js
+++ b/backend/controllers/search.controller.js
@@ -13,10 +13,9 @@ exports.globalSearch = async (req, res) => {
       category,
       priceMin,
       priceMax,
-      rating,
       page = 1,
       limit = 20,
-      sortBy = 'relevance' // 'relevance', 'price', 'rating', 'newest'
+      sortBy = 'relevance' // 'relevance', 'price', 'newest'
     } = req.query;
 
     const searchResults = {
@@ -77,9 +76,6 @@ exports.globalSearch = async (req, res) => {
 
       let businessSort = {};
       switch (sortBy) {
-        case 'rating':
-          businessSort = { averageRating: -1 };
-          break;
         case 'newest':
           businessSort = { createdAt: -1 };
           break;

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -95,7 +95,6 @@ export default function SearchPage() {
             >
               <option value="relevance">Most Relevant</option>
               <option value="price">Price: Low to High</option>
-              <option value="rating">Highest Rated</option>
               <option value="newest">Newest First</option>
             </select>
             


### PR DESCRIPTION
## Summary
- drop unused `rating` sort case from search controller
- remove rating option from the search page

## Testing
- `npm test` *(fails: TypeError argument handler must be a function)*

------
https://chatgpt.com/codex/tasks/task_e_6868bcdf9144832ba027df5735f17a8a