### PR TITLE
Apply location/category filters to sellables

### DIFF
--- a/backend/controllers/search.controller.js
+++ b/backend/controllers/search.controller.js
@@ -129,9 +129,25 @@ exports.globalSearch = async (req, res) => {
         .limit(parseInt(limit))
         .skip((parseInt(page) - 1) * parseInt(limit));
 
+      const filteredSellables = sellables.filter(sellable => {
+        const business = sellable.businessId;
+        if (!business || !business.isVerified) return false;
+        if (locationFilter.locationId &&
+            (!business.locationId ||
+              business.locationId._id.toString() !== locationFilter.locationId.toString())) {
+          return false;
+        }
+        if (categoryFilter.categoryId &&
+            (!business.categoryId ||
+              business.categoryId._id.toString() !== categoryFilter.categoryId.toString())) {
+          return false;
+        }
+        return true;
+      });
+
       // Separate products and services
-      searchResults.products = sellables.filter(s => s.type === 'product');
-      searchResults.services = sellables.filter(s => s.type === 'service');
+      searchResults.products = filteredSellables.filter(s => s.type === 'product');
+      searchResults.services = filteredSellables.filter(s => s.type === 'service');
     }
 
     // Calculate total results

--- a/backend/tests/search.test.js
+++ b/backend/tests/search.test.js
@@ -225,6 +225,56 @@ describe('Search API', () => {
       expect(res.body.data.businesses.length + res.body.data.products.length + res.body.data.services.length).toBeGreaterThan(1);
     });
 
+    it('should filter businesses by location', async () => {
+      const res = await request(app)
+        .get('/api/search')
+        .query({ type: 'business', location: 'Metro Manila' });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.businesses).toHaveLength(2);
+      res.body.data.businesses.forEach(b => {
+        expect(b.locationId.name).toBe('Metro Manila');
+      });
+    });
+
+    it('should filter products by location', async () => {
+      const res = await request(app)
+        .get('/api/search')
+        .query({ type: 'product', location: 'Metro Manila' });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.products).toHaveLength(2);
+      res.body.data.products.forEach(p => {
+        expect(p.businessId.locationId.name).toBe('Metro Manila');
+      });
+    });
+
+    it('should filter businesses by category', async () => {
+      const res = await request(app)
+        .get('/api/search')
+        .query({ type: 'business', category: 'Food' });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.businesses).toHaveLength(2);
+      res.body.data.businesses.forEach(b => {
+        expect(b.categoryId.name).toBe('Food');
+      });
+    });
+
+    it('should filter services by category', async () => {
+      const res = await request(app)
+        .get('/api/search')
+        .query({ type: 'service', category: 'Technology' });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.services).toHaveLength(1);
+      expect(res.body.data.services[0].businessId.categoryId.name).toBe('Technology');
+    });
+
     it('should filter by price range', async () => {
       const res = await request(app)
         .get('/api/search')


### PR DESCRIPTION
## Summary
- filter sellables by business location and category in search controller
- provide simple chat route handlers for test suite
- add unit tests covering location and category filtering
- use MongoDB for chat messages instead of in-memory storage

## Testing
- `npm test` *(fails: MongooseServerSelectionError - connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6868bf0707d4832b8a7143dcd075c355