### PR TITLE
Fix dashboard layout for theme

### DIFF
--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -6,10 +6,8 @@ const inter = Inter({
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
     return (
-        <html>
-            <body className={`${inter.className}`}>
-                {children}
-            </body>
-        </html>
+        <div className={inter.className}>
+            {children}
+        </div>
     );
 }


### PR DESCRIPTION
## Summary
- use a `<div>` wrapper instead of a nested `<html><body>` in the dashboard layout

## Testing
- `npm test` *(fails: listen EADDRINUSE / MongooseServerSelectionError)*

------
https://chatgpt.com/codex/tasks/task_e_686d3098f600832ba6f560eeca1536c4